### PR TITLE
Get module working with TF v1.5.2

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -235,12 +235,12 @@ data "azurerm_virtual_network" "vnet01" {
 }
 
 resource "azurerm_subnet" "snet-ep" {
-  count                                          = var.enable_private_endpoint && var.existing_subnet_id == null ? 1 : 0
-  name                                           = "snet-endpoint-${local.location}"
-  resource_group_name                            = var.existing_vnet_id == null ? data.azurerm_virtual_network.vnet01.0.resource_group_name : element(split("/", var.existing_vnet_id), 4)
-  virtual_network_name                           = var.existing_vnet_id == null ? data.azurerm_virtual_network.vnet01.0.name : element(split("/", var.existing_vnet_id), 8)
-  address_prefixes                               = var.private_subnet_address_prefix
-  enforce_private_link_endpoint_network_policies = true
+  count                                     = var.enable_private_endpoint && var.existing_subnet_id == null ? 1 : 0
+  name                                      = "snet-endpoint-${local.location}"
+  resource_group_name                       = var.existing_vnet_id == null ? data.azurerm_virtual_network.vnet01.0.resource_group_name : element(split("/", var.existing_vnet_id), 4)
+  virtual_network_name                      = var.existing_vnet_id == null ? data.azurerm_virtual_network.vnet01.0.name : element(split("/", var.existing_vnet_id), 8)
+  address_prefixes                          = var.private_subnet_address_prefix
+  private_endpoint_network_policies_enabled = true
 }
 
 resource "azurerm_private_endpoint" "pep1" {

--- a/main.tf
+++ b/main.tf
@@ -88,10 +88,10 @@ locals {
   self_permissions = {
     object_id               = local.service_principal_object_id
     tenant_id               = data.azurerm_client_config.current.tenant_id
-    key_permissions         = ["create", "delete", "get", "backup", "decrypt", "encrypt", "import", "list", "purge", "recover", "restore", "sign", "update", "verify"]
-    secret_permissions      = ["backup", "delete", "get", "list", "purge", "recover", "restore", "set"]
-    certificate_permissions = ["backup", "create", "delete", "deleteissuers", "get", "getissuers", "import", "list", "listissuers", "managecontacts", "manageissuers", "purge", "recover", "restore", "setissuers", "update"]
-    storage_permissions     = ["backup", "delete", "deletesas", "get", "getsas", "list", "listsas", "purge", "recover", "regeneratekey", "restore", "set", "setsas", "update"]
+    key_permissions         = ["Create", "Delete", "Get", "Backup", "Decrypt", "Encrypt", "Import", "List", "Purge", "Recover", "Restore", "Sign", "Update", "Verify"]
+    secret_permissions      = ["Backup", "Delete", "Get", "List", "Purge", "Recover", "Restore", "Set"]
+    certificate_permissions = ["Backup", "Create", "Delete", "DeleteIssuers", "Get", "GetIssuers", "Import", "List", "ListIssuers", "ManageContacts", "ManageIssuers", "Purge", "Recover", "Restore", "SetIssuers", "Update"]
+    storage_permissions     = ["Backup", "Delete", "DeleteSAS", "Get", "GetSAS", "List", "ListSAS", "Purge", "Recover", "RegenerateKey", "Restore", "Set", "SetSAS", "Update"]
   }
 }
 

--- a/output.tf
+++ b/output.tf
@@ -18,6 +18,11 @@ output "secrets" {
   value       = { for k, v in azurerm_key_vault_secret.keys : v.name => v.id }
 }
 
+output "versionless_resource_secrets" {
+  description = "A mapping of secret names and and versionless resource IDs."
+  value       = { for k, v in azurerm_key_vault_secret.keys : v.name => v.resource_versionless_id }
+}
+
 output "key_vault_references" {
   description = "A mapping of Key Vault references for App Service and Azure Functions."
   value = {

--- a/output.tf
+++ b/output.tf
@@ -18,8 +18,18 @@ output "secrets" {
   value       = { for k, v in azurerm_key_vault_secret.keys : v.name => v.id }
 }
 
+output "versionless_secrets" {
+  description = "A mapping of secret names and versionless IDs."
+  value       = { for k, v in azurerm_key_vault_secret.keys : v.name => v.versionless_id }
+}
+
+output "resource_secrets" {
+  description = "A mapping of secret names and resource IDs."
+  value       = { for k, v in azurerm_key_vault_secret.keys : v.name => v.resource_id }
+}
+
 output "versionless_resource_secrets" {
-  description = "A mapping of secret names and and versionless resource IDs."
+  description = "A mapping of secret names and versionless resource IDs."
   value       = { for k, v in azurerm_key_vault_secret.keys : v.name => v.resource_versionless_id }
 }
 

--- a/output.tf
+++ b/output.tf
@@ -41,6 +41,14 @@ output "key_vault_references" {
   }
 }
 
+output "versionless_key_vault_references" {
+  description = "A mapping of Key Vault versionless references for App Service and Azure Functions."
+  value = {
+    for k, v in azurerm_key_vault_secret.keys :
+    v.name => format("@Microsoft.KeyVault(SecretUri=%s)", v.versionless_id)
+  }
+}
+
 output "key_vault_private_endpoint" {
   description = "The ID of the Key Vault Private Endpoint"
   value       = var.enable_private_endpoint ? element(concat(azurerm_private_endpoint.pep1.*.id, [""]), 0) : null

--- a/output.tf
+++ b/output.tf
@@ -18,7 +18,7 @@ output "secrets" {
   value       = { for k, v in azurerm_key_vault_secret.keys : v.name => v.id }
 }
 
-output "Key_vault_references" {
+output "key_vault_references" {
   description = "A mapping of Key Vault references for App Service and Azure Functions."
   value = {
     for k, v in azurerm_key_vault_secret.keys :

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,4 @@
 terraform {
-  experiments = [module_variable_optional_attrs]
   required_providers {
     azuread = {
       source  = "hashicorp/azuread"


### PR DESCRIPTION
Fixes 2 issues that blocked me from running `terraform plan` with Terraform v1.5.2:
- Permission types (e.g. `DeleteSAS`) must be Pascal-cased
- `module_variable_optional_attrs` experiment is no longer available

 and fixes one warning:
- `azurerm_subnet.enforce_private_link_endpoint_network_policies` has been replaced with `azurerm_subnet. private_endpoint_network_policies_enabled `