### PR TITLE
chore: update to terraform v1.3.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,4 @@
 terraform {
-  experiments = [module_variable_optional_attrs]
   required_providers {
     azuread = {
       source  = "hashicorp/azuread"
@@ -14,5 +13,5 @@ terraform {
       version = ">= 3.1.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.3.0"
 }


### PR DESCRIPTION
This PR removes the `module_variable_optional_attrs` experiment, which is no longer available as of Terraform v1.3.0, and updates the `required_version` of Terraform to be `>= 1.3.0`